### PR TITLE
Updates metadata for Gnome 50

### DIFF
--- a/messagingmenu@lauinger-clan.de/metadata.json
+++ b/messagingmenu@lauinger-clan.de/metadata.json
@@ -1,15 +1,16 @@
 {
-    "shell-version": ["48", "49"],
-    "uuid": "messagingmenu@lauinger-clan.de",
     "name": "Messaging Menu",
-    "original-author": "sinisterstuf",
     "gettext-domain": "messagingmenu",
     "description": "A Messaging Menu for the Gnome Shell. All Email and Chat Applications in one Place.",
+    "uuid": "messagingmenu@lauinger-clan.de",
+    "shell-version": ["48", "49", "50"],
+    "original-author": "sinisterstuf",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-messagingmenu",
     "settings-schema": "org.gnome.shell.extensions.messagingmenu",
     "donations": {
         "github": "ChrisLauinger77",
         "paypal": "ChrisLauinger"
     },
-    "version-name": "49.6"
+    "version": 999,
+    "version-name": "50.0"
 }

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:55+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Skryf Nuwe Boodskap"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Kontakte"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Kies toepassing"

--- a/po/cz.po
+++ b/po/cz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:58+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Czech\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Vytvořit novou zprávu"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Kontakty"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -120,7 +120,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Vybrat aplikaci"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2025-12-03 19:31+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Neue Nachricht erstellen"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Kontakte"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] "Scan hat %d Applikation gefunden"
 msgstr[1] "Scan hat %d Applikationen gefunden"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "App auswählen"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:55+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Spanish\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Crear un Nuevo Mensaje"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Contactos"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Seleccionar aplicación"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: French\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Composer un Nouveau Message"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Contacts"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Sélectionner l'application"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Hungarian\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Új üzenet írása"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Kapcsolatok"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Alkalmazás kiválasztása"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Italian\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Componi un Nuovo Messaggio"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Contatti"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -120,7 +120,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Seleziona app"

--- a/po/messagingmenu.pot
+++ b/po/messagingmenu.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:59+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Bericht opstellen"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Contactpersonen"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Selecteer app"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Polish\n"
@@ -20,15 +20,15 @@ msgstr ""
 "X-Generator: Poedit 3.6\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Napisz nową wiadomość"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Kontakty"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -122,7 +122,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Wybierz aplikację"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:57+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Escrever Nova Mensagem"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Contatos"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -119,7 +119,7 @@ msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Selecionar aplicativo"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2025-09-11 21:56+0300\n"
 "Last-Translator: Fraxinus Acer\n"
 "Language-Team: Russian\n"
@@ -20,15 +20,15 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Создать Новое Сообщение"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Контакты"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -122,7 +122,7 @@ msgstr[0] "Сканирование нашло %d приложение"
 msgstr[1] "Сканирование нашло %d приложения"
 msgstr[2] "Сканирование нашло %d приложений"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Выбрать приложение"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 17:26+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:56+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Turkish <>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:61
+#: messagingmenu@lauinger-clan.de/extension.js:52
 msgid "Compose New Message"
 msgstr "Yeni İleti Oluştur"
 
-#: messagingmenu@lauinger-clan.de/extension.js:62
+#: messagingmenu@lauinger-clan.de/extension.js:53
 msgid "Contacts"
 msgstr "Kişiler"
 
-#: messagingmenu@lauinger-clan.de/extension.js:226
+#: messagingmenu@lauinger-clan.de/extension.js:218
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
@@ -118,7 +118,7 @@ msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:356
+#: messagingmenu@lauinger-clan.de/prefs.js:357
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:59
 msgid "Select app"
 msgstr "Uygulama seç"


### PR DESCRIPTION
Updates the metadata.json file to include Gnome Shell version 50 support.

Also, reorders the keys and increments the version number to reflect the changes.
